### PR TITLE
Prevent error when right-clicking in unfocused window

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,16 +8,14 @@ const menu = new remote.Menu();
 menu.append(new remote.MenuItem({
   label: 'Inspect element',
   click: () => {
-    remote.BrowserWindow
-      .getFocusedWindow()
-      .inspectElement(rightClickPos.x, rightClickPos.y);
+    remote.getCurrentWindow().inspectElement(rightClickPos.x, rightClickPos.y);
   }
 }));
 
 function onContextMenu(e) {
   e.preventDefault();
   rightClickPos = {x: e.x, y: e.y};
-  menu.popup();
+  menu.popup(remote.getCurrentWindow());
 }
 
 exports.install = () => {


### PR DESCRIPTION
Currently, if I right click in an Electron window that is not focused, the debug menu throws an error when attempting to `popup()`. This change prevents that error.
