### PR TITLE
Fixed a bug where 'Inspect element' would always inspect the same element. Fixed some typos.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,15 +3,18 @@
 const electron = require('electron');
 
 let menu = null;
+let posX = 0;
+let posY = 0;
+let elm = null;
 
-function inpectMenuTemplate(pos, elm) {
+function inspectMenuTemplate() {
 	return {
 		label: 'Inspect element',
-		click: () => (elm || electron.remote.getCurrentWindow()).inspectElement(pos.x, pos.y)
+		click: () => (elm || electron.remote.getCurrentWindow()).inspectElement(posX, posY)
 	};
 }
 
-function inpectElementMenu(pos, elm) {
+function inspectElementMenu() {
 	const Menu = process.type === 'renderer' ?
 		electron.remote.Menu :
 		electron.Menu;
@@ -23,7 +26,7 @@ function inpectElementMenu(pos, elm) {
 	const mnu = new Menu();
 
 	mnu.append(new MenuItem(
-		inpectMenuTemplate(pos, elm)
+		inspectMenuTemplate()
 	));
 
 	return mnu;
@@ -37,14 +40,19 @@ function ifInspectable(elm) {
 
 function onContextMenu(e) {
 	if (menu === null) {
-		menu = inpectElementMenu({x: e.x, y: e.y}, ifInspectable(e.target));
+		menu = inspectElementMenu();
 	}
+
+	posX = e.x;
+	posY = e.y;
+	elm = ifInspectable(e.target);
+
 	e.preventDefault();
 	menu.popup(electron.remote.getCurrentWindow());
 }
 
 exports.middleware = (ctx, next) => {
-	ctx.menu.push(inpectMenuTemplate(ctx.click, ifInspectable(ctx.elm)));
+	ctx.menu.push(inspectMenuTemplate(ctx.click, ifInspectable(ctx.elm)));
 	next();
 };
 

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ exports.middleware = (ctx, next) => {
 	posX = ctx.click.x;
 	posY = ctx.click.y;
 	elm = ifInspectable(ctx.elm);
-	
+
 	ctx.menu.push(inspectMenuTemplate());
 	next();
 };

--- a/index.js
+++ b/index.js
@@ -52,7 +52,11 @@ function onContextMenu(e) {
 }
 
 exports.middleware = (ctx, next) => {
-	ctx.menu.push(inspectMenuTemplate(ctx.click, ifInspectable(ctx.elm)));
+	posX = ctx.click.x;
+	posY = ctx.click.y;
+	elm = ifInspectable(ctx.elm);
+	
+	ctx.menu.push(inspectMenuTemplate());
 	next();
 };
 


### PR DESCRIPTION
When you inspected your first element, it and its position was cached when creating the context menu. So the same element and position would always be passed into inspectMenuTemplate() whenever you tried to inspect another element.

I stored the element and the coordinates in variables outside the functions to fix this. You could also just remove the if statement on line 42, so this: 

```javascript
function onContextMenu(e) {
  if (menu === null) {
    menu = inpectElementMenu({x: e.x, y: e.y}, ifInspectable(e.target));
  }
```

becomes:

```javascript
function onContextMenu(e) {
    menu = inpectElementMenu({x: e.x, y: e.y}, ifInspectable(e.target));
```

without needing to changing anything else. But that would create a new menu every time you right-click, and I thought that was something you didn't want.

Also fixed some typos I found.